### PR TITLE
BUG: replace whitespaces with dashes in filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install dependencies:
 npm install
 ```
 
-Create your product files inside the `products/` folder, and before pushing changes to the remote repository, make sure that the following commands run successfully (otherwise the Continuous Integration (CI) tests will fail, and your contributions could not be merged until these errors are corrected):
+Create your product files inside the `products/` folder. The filename for each product should match the `name` field in that product in [kebab-case](https://wiki.c2.com/?KebabCase). Before pushing changes to the remote repository, make sure that the following commands run successfully (otherwise the Continuous Integration (CI) tests will fail, and your contributions could not be merged until these errors are corrected):
 
 * Validate the JSON schema of all product files:
 
@@ -40,7 +40,7 @@ Create your product files inside the `products/` folder, and before pushing chan
 	npm run lint
 	```
 
-* Check proper naming of all product files:
+* Check proper naming of all product files. Again, this will check that the filename matches that file `name` field in kebab case (i.e. spaces replaced by dashes):
 
 	```bash
 	./scripts/check-filenames.bash

--- a/scripts/check-filenames.bash
+++ b/scripts/check-filenames.bash
@@ -19,7 +19,7 @@ if [ `ls -1 ./products/*.json 2>/dev/null | wc -l` -gt 0 ]; then
 				mv "$f" "./products/$filename.json"
 				echo "Filename has been renamed: $filename.json"
 	    	else
-	    		echo "Filename is not valid: $(basename -- "$f"), it should be $filename.json"
+	    		echo "Filename is not valid: $(basename -- "$f"), it should be $filename.json, where the filename must match the 'name' field in kebab case."
 	    		echo "Run this script with --fix to rename the file(s) automatically."
 	    		popd > /dev/null 2>&1
 				exit 1

--- a/scripts/check-filenames.bash
+++ b/scripts/check-filenames.bash
@@ -11,13 +11,13 @@ pushd $SELFDIR/.. > /dev/null 2>&1
 
 if [ `ls -1 ./products/*.json 2>/dev/null | wc -l` -gt 0 ]; then
 	for f in ./products/*.json; do
-	    filename=`grep -Eo -m 1 '"name":.*?[^\\]",' $f | awk -F':' '{print $2}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]/-/'| tr '[:upper:]' '[:lower:]'`
+	    filename=`grep -Eo -m 1 '"name":.*?[^\\]",' "$f" | awk -F':' '{print $2}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]/-/'| tr '[:upper:]' '[:lower:]'`
 	    if [ "$filename.json" = "$(basename -- "$f")" ]; then
 	    	echo "Filename is valid: $filename.json"
 	    else
 	    	if [ $FIX = 1 ]; then
-	    		mv $f ./products/$filename.json
-	    		echo "Filename has been renamed: $filename.json"
+				mv "$f" "./products/$filename.json"
+				echo "Filename has been renamed: $filename.json"
 	    	else
 	    		echo "Filename is not valid: $(basename -- "$f"), it should be $filename.json"
 	    		echo "Run this script with --fix to rename the file(s) automatically."

--- a/scripts/check-filenames.bash
+++ b/scripts/check-filenames.bash
@@ -11,7 +11,7 @@ pushd $SELFDIR/.. > /dev/null 2>&1
 
 if [ `ls -1 ./products/*.json 2>/dev/null | wc -l` -gt 0 ]; then
 	for f in ./products/*.json; do
-	    filename=`grep -Eo -m 1 '"name":.*?[^\\]",' $f | awk -F':' '{print $2}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' | tr '[:upper:]' '[:lower:]'`
+	    filename=`grep -Eo -m 1 '"name":.*?[^\\]",' $f | awk -F':' '{print $2}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]/-/'| tr '[:upper:]' '[:lower:]'`
 	    if [ "$filename.json" = "$(basename -- "$f")" ]; then
 	    	echo "Filename is valid: $filename.json"
 	    else


### PR DESCRIPTION
Modified `check-filenames.bash` script to replace whitespaces in name with dashes, otherwise the whitespaces are not escaped and not handled properly by the script itself.