### PR TITLE
MAINT: replace link -> licenseURL

### DIFF
--- a/products/5calls-frontend.json
+++ b/products/5calls-frontend.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/5calls/5calls/blob/master/LICENSE.txt"
+      "licenseURL": "https://github.com/5calls/5calls/blob/master/LICENSE.txt"
     }
   ],
   "website": "https://5calls.org/",

--- a/products/5calls-ios.json
+++ b/products/5calls-ios.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/5calls/ios/blob/master/LICENSE"
+      "licenseURL": "https://github.com/5calls/ios/blob/master/LICENSE"
     }
   ],
   "website": "https://5calls.org/",

--- a/products/accessibility-cloud.json
+++ b/products/accessibility-cloud.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/sozialhelden/accessibility-cloud/blob/master/LICENSE"
+      "licenseURL": "https://github.com/sozialhelden/accessibility-cloud/blob/master/LICENSE"
     }
   ],
   "website": "https://www.accessibility.cloud/",

--- a/products/adopt-a-drain.json
+++ b/products/adopt-a-drain.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "link": "https://github.com/sfbrigade/adopt-a-drain/blob/master/LICENSE.md"
+      "licenseURL": "https://github.com/sfbrigade/adopt-a-drain/blob/master/LICENSE.md"
     }
   ],
   "website": "https://adoptadrain.sfwater.org/",

--- a/products/aid-transparency-tracker.json
+++ b/products/aid-transparency-tracker.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/pwyf/aid-transparency-tracker/blob/2020tracker/license.txt"
+      "licenseURL": "https://github.com/pwyf/aid-transparency-tracker/blob/2020tracker/license.txt"
     }
   ],
   "website": "https://www.publishwhatyoufund.org/projects/humanitarian-transparency/",

--- a/products/alaveteli.json
+++ b/products/alaveteli.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/mysociety/alaveteli/blob/develop/LICENSE.txt"
+      "licenseURL": "https://github.com/mysociety/alaveteli/blob/develop/LICENSE.txt"
     }
   ],
   "website": "http://alaveteli.org",

--- a/products/alex-atom-linter.json
+++ b/products/alex-atom-linter.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/get-alex/atom-linter-alex/blob/master/license"
+      "licenseURL": "https://github.com/get-alex/atom-linter-alex/blob/master/license"
     }
   ],
   "website": "",

--- a/products/alex-sublime-linter.json
+++ b/products/alex-sublime-linter.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/get-alex/SublimeLinter-contrib-alex/blob/master/license"
+      "licenseURL": "https://github.com/get-alex/SublimeLinter-contrib-alex/blob/master/license"
     }
   ],
   "website": "",

--- a/products/alex.json
+++ b/products/alex.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/get-alex/alex/blob/master/license"
+      "licenseURL": "https://github.com/get-alex/alex/blob/master/license"
     }
   ],
   "website": "",

--- a/products/all-ready.json
+++ b/products/all-ready.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/HTBox/allReady/blob/master/LICENSE"
+      "licenseURL": "https://github.com/HTBox/allReady/blob/master/LICENSE"
     }
   ],
   "website": "http://www.htbox.org/projects/allready",

--- a/products/android-guides.json
+++ b/products/android-guides.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": ""
+      "licenseURL": ""
     }
   ],
   "website": "http://guides.codepath.com",

--- a/products/api.gouv.fr.json
+++ b/products/api.gouv.fr.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/betagouv/api.gouv.fr/blob/master/LICENSE"
+      "licenseURL": "https://github.com/betagouv/api.gouv.fr/blob/master/LICENSE"
     }
   ],
   "website": "https://api.gouv.fr/",

--- a/products/arkhn-fhir-pipe.json
+++ b/products/arkhn-fhir-pipe.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/arkhn/fhir-pipe/blob/master/LICENSE"
+      "licenseURL": "https://github.com/arkhn/fhir-pipe/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/ask.json
+++ b/products/ask.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/coralproject/ask/blob/master/LICENSE"
+      "licenseURL": "https://github.com/coralproject/ask/blob/master/LICENSE"
     }
   ],
   "website": "https://github.com/coralproject/ask",

--- a/products/askdarcel-api.json
+++ b/products/askdarcel-api.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/ShelterTechSF/askdarcel-api/blob/master/LICENSE"
+      "licenseURL": "https://github.com/ShelterTechSF/askdarcel-api/blob/master/LICENSE"
     }
   ],
   "website": "https://askdarcel.org/",

--- a/products/askdarcel.json
+++ b/products/askdarcel.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/ShelterTechSF/askdarcel-web/blob/master/LICENSE"
+      "licenseURL": "https://github.com/ShelterTechSF/askdarcel-web/blob/master/LICENSE"
     }
   ],
   "website": "https://askdarcel.org/",

--- a/products/aster-emergency-scoring.json
+++ b/products/aster-emergency-scoring.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/Project-AsTeR/scoring/blob/master/LICENSE"
+      "licenseURL": "https://github.com/Project-AsTeR/scoring/blob/master/LICENSE"
     }
   ],
   "website": "https://www.project-aster.com",

--- a/products/aster-platform.json
+++ b/products/aster-platform.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/Project-AsTeR/website/blob/master/LICENSE"
+      "licenseURL": "https://github.com/Project-AsTeR/website/blob/master/LICENSE"
     }
   ],
   "website": "https://www.project-aster.com",

--- a/products/aster-stream.json
+++ b/products/aster-stream.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/Project-AsTeR/stream/blob/master/LICENSE"
+      "licenseURL": "https://github.com/Project-AsTeR/stream/blob/master/LICENSE"
     }
   ],
   "website": "https://www.project-aster.com",

--- a/products/asylumconnect-catalog.json
+++ b/products/asylumconnect-catalog.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/AsylumConnect/asylum-connect-catalog/blob/master/LICENSE.md"
+      "licenseURL": "https://github.com/AsylumConnect/asylum-connect-catalog/blob/master/LICENSE.md"
     }
   ],
   "website": "https://catalog.asylumconnect.org/",

--- a/products/autofocus.json
+++ b/products/autofocus.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "link": "https://github.com/uptake/autofocus/blob/master/LICENSE"
+      "licenseURL": "https://github.com/uptake/autofocus/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/bias-correct.json
+++ b/products/bias-correct.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/EskaleraInc/catalyst-bias-correct/blob/master/LICENSE"
+      "licenseURL": "https://github.com/EskaleraInc/catalyst-bias-correct/blob/master/LICENSE"
     }
   ],
   "website": "https://catalyst.org/biascorrect",

--- a/products/blockly.json
+++ b/products/blockly.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/code-dot-org/blockly/blob/master/COPYING"
+      "licenseURL": "https://github.com/code-dot-org/blockly/blob/master/COPYING"
     }
   ],
   "website": "https://code-dot-org.github.io/blockly/tests/playground.html",

--- a/products/bob-emploi.json
+++ b/products/bob-emploi.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/bayesimpact/bob-emploi/blob/master/LICENSE"
+      "licenseURL": "https://github.com/bayesimpact/bob-emploi/blob/master/LICENSE"
     }
   ],
   "website": "https://www.bob-emploi.fr/",

--- a/products/callisto-core.json
+++ b/products/callisto-core.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/project-callisto/callisto-core/blob/master/LICENSE"
+      "licenseURL": "https://github.com/project-callisto/callisto-core/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/camicroscope.json
+++ b/products/camicroscope.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "link": "https://github.com/camicroscope/caMicroscope/blob/master/LICENSE"
+      "licenseURL": "https://github.com/camicroscope/caMicroscope/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/carbon-inferno.json
+++ b/products/carbon-inferno.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/giving-a-fuck-about-climate-change/carbon-inferno/blob/master/LICENSE"
+      "licenseURL": "https://github.com/giving-a-fuck-about-climate-change/carbon-inferno/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/census-api.json
+++ b/products/census-api.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "link": "https://github.com/datamade/census/blob/master/LICENSE"
+      "licenseURL": "https://github.com/datamade/census/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/centre-for-open-science-share.json
+++ b/products/centre-for-open-science-share.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/CenterForOpenScience/SHARE/blob/develop/LICENSE"
+      "licenseURL": "https://github.com/CenterForOpenScience/SHARE/blob/develop/LICENSE"
     }
   ],
   "website": "https://share-research.readthedocs.io/en/latest/index.html",

--- a/products/cgmblekit.json
+++ b/products/cgmblekit.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/LoopKit/CGMBLEKit/blob/master/LICENSE"
+      "licenseURL": "https://github.com/LoopKit/CGMBLEKit/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/child-growth-monitor.json
+++ b/products/child-growth-monitor.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/Welthungerhilfe/cgm-ml/blob/master/LICENSE"
+      "licenseURL": "https://github.com/Welthungerhilfe/cgm-ml/blob/master/LICENSE"
     }
   ],
   "website": "https://childgrowthmonitor.org/",

--- a/products/civic-platform.json
+++ b/products/civic-platform.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/hackoregon/civic/blob/master/LICENSE"
+      "licenseURL": "https://github.com/hackoregon/civic/blob/master/LICENSE"
     }
   ],
   "website": "http://civicplatform.org/",

--- a/products/climatewatch.json
+++ b/products/climatewatch.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/Vizzuality/climate-watch/blob/develop/LICENSE"
+      "licenseURL": "https://github.com/Vizzuality/climate-watch/blob/develop/LICENSE"
     }
   ],
   "website": "https://www.climatewatchdata.org/",

--- a/products/code-for-america-api.json
+++ b/products/code-for-america-api.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/codeforamerica/cfapi/blob/master/LICENSE"
+      "licenseURL": "https://github.com/codeforamerica/cfapi/blob/master/LICENSE"
     }
   ],
   "website": "http://codeforamerica.org/api",

--- a/products/code-for-america-brigade-website.json
+++ b/products/code-for-america-brigade-website.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/codeforamerica/brigade/blob/master/LICENSE"
+      "licenseURL": "https://github.com/codeforamerica/brigade/blob/master/LICENSE"
     }
   ],
   "website": "https://brigade.codeforamerica.org",

--- a/products/code.org.json
+++ b/products/code.org.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/code-dot-org/code-dot-org/blob/staging/LICENSE"
+      "licenseURL": "https://github.com/code-dot-org/code-dot-org/blob/staging/LICENSE"
     }
   ],
   "website": "",

--- a/products/commcare-android.json
+++ b/products/commcare-android.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/dimagi/commcare-android/blob/master/LICENSE"
+      "licenseURL": "https://github.com/dimagi/commcare-android/blob/master/LICENSE"
     }
   ],
   "website": "https://play.google.com/store/apps/details?id=org.commcare.dalvik&hl=en",

--- a/products/commcare-cloud.json
+++ b/products/commcare-cloud.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "link": "https://github.com/dimagi/commcare-cloud/blob/master/LICENSE"
+      "licenseURL": "https://github.com/dimagi/commcare-cloud/blob/master/LICENSE"
     }
   ],
   "website": "https://dimagi.github.io/commcare-cloud/",

--- a/products/commcare.json
+++ b/products/commcare.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "link": "https://github.com/dimagi/commcare-hq/blob/master/LICENSE"
+      "licenseURL": "https://github.com/dimagi/commcare-hq/blob/master/LICENSE"
     }
   ],
   "website": "https://www.commcarehq.org/accounts/login/",

--- a/products/community-health-toolkit.json
+++ b/products/community-health-toolkit.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/medic/cht-core/blob/master/LICENSE"
+      "licenseURL": "https://github.com/medic/cht-core/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/consul.json
+++ b/products/consul.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/consul/consul/blob/master/LICENSE-AGPLv3.txt"
+      "licenseURL": "https://github.com/consul/consul/blob/master/LICENSE-AGPLv3.txt"
     }
   ],
   "website": "http://consulproject.org/en/",

--- a/products/crash-model.json
+++ b/products/crash-model.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/Data4Democracy/crash-model/blob/master/LICENSE"
+      "licenseURL": "https://github.com/Data4Democracy/crash-model/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/croquemort.json
+++ b/products/croquemort.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/etalab/croquemort/blob/master/LICENSE"
+      "licenseURL": "https://github.com/etalab/croquemort/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/datascope.json
+++ b/products/datascope.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "link": "https://github.com/sharmalab/Datascope/blob/master/LICENSE"
+      "licenseURL": "https://github.com/sharmalab/Datascope/blob/master/LICENSE"
     }
   ],
   "website": "https://sharmalab.github.io/Datascope/",

--- a/products/decidim.json
+++ b/products/decidim.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/OpenSourcePolitics/decidim/blob/master/LICENSE-AGPLv3.txt"
+      "licenseURL": "https://github.com/OpenSourcePolitics/decidim/blob/master/LICENSE-AGPLv3.txt"
     }
   ],
   "website": "http://www.decidim.org",

--- a/products/demarches-simplifiees.json
+++ b/products/demarches-simplifiees.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/LICENSE.txt"
+      "licenseURL": "https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/LICENSE.txt"
     }
   ],
   "website": "http://demarches-simplifiees.fr",

--- a/products/deon.json
+++ b/products/deon.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/drivendataorg/deon/blob/master/LICENSE.txt"
+      "licenseURL": "https://github.com/drivendataorg/deon/blob/master/LICENSE.txt"
     }
   ],
   "website": "http://deon.drivendata.org/",

--- a/products/diaper.json
+++ b/products/diaper.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/rubyforgood/diaper/blob/master/LICENSE"
+      "licenseURL": "https://github.com/rubyforgood/diaper/blob/master/LICENSE"
     }
   ],
   "website": "https://diaper.app/",

--- a/products/dollar-street-pages.json
+++ b/products/dollar-street-pages.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/Gapminder/dollar-street-pages/blob/development/LICENSE"
+      "licenseURL": "https://github.com/Gapminder/dollar-street-pages/blob/development/LICENSE"
     }
   ],
   "website": "https://www.gapminder.org/dollar-street/about",

--- a/products/driver.json
+++ b/products/driver.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/WorldBank-Transport/DRIVER/blob/master/LICENSE"
+      "licenseURL": "https://github.com/WorldBank-Transport/DRIVER/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/ebola-response-platform.json
+++ b/products/ebola-response-platform.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/OSU-Battelle-Center/DRC-Ebola-Conflict/blob/master/LICENSE"
+      "licenseURL": "https://github.com/OSU-Battelle-Center/DRC-Ebola-Conflict/blob/master/LICENSE"
     }
   ],
   "website": "https://osu-battelle-center.github.io/DRC-Ebola-Conflict/",

--- a/products/eden.json
+++ b/products/eden.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/sahana/eden/blob/master/LICENSE"
+      "licenseURL": "https://github.com/sahana/eden/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/electricitymap.json
+++ b/products/electricitymap.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/tmrowco/electricitymap-contrib/blob/master/LICENSE.txt"
+      "licenseURL": "https://github.com/tmrowco/electricitymap-contrib/blob/master/LICENSE.txt"
     }
   ],
   "website": "https://www.electricitymap.org/?page=map&solar=false&remote=true&wind=false",

--- a/products/encompass.json
+++ b/products/encompass.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/bayesimpact/encompass/blob/master/LICENSE.md"
+      "licenseURL": "https://github.com/bayesimpact/encompass/blob/master/LICENSE.md"
     }
   ],
   "website": "https://encompass.thebeaconlabs.org/",

--- a/products/energy-web-ui.json
+++ b/products/energy-web-ui.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/energywebfoundation/energyweb-ui/blob/master/LICENSE"
+      "licenseURL": "https://github.com/energywebfoundation/energyweb-ui/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/energydata.info.json
+++ b/products/energydata.info.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/energy-data/energydata.info/blob/develop/LICENSE"
+      "licenseURL": "https://github.com/energy-data/energydata.info/blob/develop/LICENSE"
     }
   ],
   "website": "http://energydata.info",

--- a/products/energyplus.json
+++ b/products/energyplus.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-4-Clause",
-      "link": "https://github.com/NREL/EnergyPlus/blob/develop/LICENSE.txt"
+      "licenseURL": "https://github.com/NREL/EnergyPlus/blob/develop/LICENSE.txt"
     }
   ],
   "website": "https://energyplus.net",

--- a/products/enketo-core.json
+++ b/products/enketo-core.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/enketo/enketo-core/blob/master/LICENSE"
+      "licenseURL": "https://github.com/enketo/enketo-core/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/enketo-express.json
+++ b/products/enketo-express.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "link": "https://github.com/enketo/enketo-express/blob/master/LICENSE"
+      "licenseURL": "https://github.com/enketo/enketo-express/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/environmental-layers.json
+++ b/products/environmental-layers.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/publiclab/leaflet-environmental-layers/blob/master/LICENSE"
+      "licenseURL": "https://github.com/publiclab/leaflet-environmental-layers/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/eviction-free-nyc.json
+++ b/products/eviction-free-nyc.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/JustFixNYC/eviction-free-nyc/blob/master/LICENSE.md"
+      "licenseURL": "https://github.com/JustFixNYC/eviction-free-nyc/blob/master/LICENSE.md"
     }
   ],
   "website": "https://www.evictionfreenyc.org",

--- a/products/eviction-maps.json
+++ b/products/eviction-maps.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/EvictionLab/eviction-maps/blob/development/LICENSE"
+      "licenseURL": "https://github.com/EvictionLab/eviction-maps/blob/development/LICENSE"
     }
   ],
   "website": "https://evictionlab.org/map/#/2016?geography=states",

--- a/products/find-training.json
+++ b/products/find-training.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/codeforamerica/etpl-search/blob/master/LICENSE"
+      "licenseURL": "https://github.com/codeforamerica/etpl-search/blob/master/LICENSE"
     }
   ],
   "website": "https://findtraining.org",

--- a/products/fix-my-street.json
+++ b/products/fix-my-street.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/mysociety/fixmystreet/blob/master/LICENSE.txt"
+      "licenseURL": "https://github.com/mysociety/fixmystreet/blob/master/LICENSE.txt"
     }
   ],
   "website": "http://fixmystreet.org/",

--- a/products/flowkit.json
+++ b/products/flowkit.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MPL-2.0",
-      "link": "https://github.com/Flowminder/FlowKit/blob/master/LICENSE"
+      "licenseURL": "https://github.com/Flowminder/FlowKit/blob/master/LICENSE"
     }
   ],
   "website": "https://flowminder.github.io/FlowKit/",

--- a/products/foodcoops.json
+++ b/products/foodcoops.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/foodcoops/foodsoft/blob/master/LICENSE.md"
+      "licenseURL": "https://github.com/foodcoops/foodsoft/blob/master/LICENSE.md"
     }
   ],
   "website": "https://foodcoops.github.io/",

--- a/products/freedom-of-information-portal.json
+++ b/products/freedom-of-information-portal.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/okfde/froide/blob/master/LICENSE.txt"
+      "licenseURL": "https://github.com/okfde/froide/blob/master/LICENSE.txt"
     }
   ],
   "website": "",

--- a/products/gapminder-offline.json
+++ b/products/gapminder-offline.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/Gapminder/gapminder-offline/blob/development/LICENSE"
+      "licenseURL": "https://github.com/Gapminder/gapminder-offline/blob/development/LICENSE"
     }
   ],
   "website": "https://www.gapminder.org/tools-offline/",

--- a/products/geonode.json
+++ b/products/geonode.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/GeoNode/geonode/blob/master/license.txt"
+      "licenseURL": "https://github.com/GeoNode/geonode/blob/master/license.txt"
     }
   ],
   "website": "",

--- a/products/global-forest-watch.json
+++ b/products/global-forest-watch.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/Vizzuality/gfw/blob/develop/LICENSE"
+      "licenseURL": "https://github.com/Vizzuality/gfw/blob/develop/LICENSE"
     }
   ],
   "website": "https://www.globalforestwatch.org/",

--- a/products/growstuff.json
+++ b/products/growstuff.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/Growstuff/growstuff/blob/dev/LICENSE.txt"
+      "licenseURL": "https://github.com/Growstuff/growstuff/blob/dev/LICENSE.txt"
     }
   ],
   "website": "",

--- a/products/heat-seek-webapp.json
+++ b/products/heat-seek-webapp.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/heatseeknyc/heatseeknyc/blob/master/LICENSE.txt"
+      "licenseURL": "https://github.com/heatseeknyc/heatseeknyc/blob/master/LICENSE.txt"
     }
   ],
   "website": "https://heatseek.org/explore-the-tech/",

--- a/products/high-resolution-mapping-of-food-security.json
+++ b/products/high-resolution-mapping-of-food-security.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/WFP-VAM/HRM/blob/master/LICENSE"
+      "licenseURL": "https://github.com/WFP-VAM/HRM/blob/master/LICENSE"
     }
   ],
   "website": "https://wfp-vam.github.io/HRM/",

--- a/products/hikmahealth.json
+++ b/products/hikmahealth.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/hikmahealth/hikma-mobile/blob/master/LICENSE"
+      "licenseURL": "https://github.com/hikmahealth/hikma-mobile/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/hospitalrun-frontend.json
+++ b/products/hospitalrun-frontend.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/HospitalRun/hospitalrun-frontend/blob/master/LICENSE"
+      "licenseURL": "https://github.com/HospitalRun/hospitalrun-frontend/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/hospitalrun-server-routes.json
+++ b/products/hospitalrun-server-routes.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/HospitalRun/hospitalrun-server-routes/blob/master/LICENSE"
+      "licenseURL": "https://github.com/HospitalRun/hospitalrun-server-routes/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/hospitalrun-server.json
+++ b/products/hospitalrun-server.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/HospitalRun/hospitalrun-server/blob/master/LICENSE"
+      "licenseURL": "https://github.com/HospitalRun/hospitalrun-server/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/hotosm-tasking-manager.json
+++ b/products/hotosm-tasking-manager.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "BSD-2-Clause",
-      "link": "https://github.com/hotosm/tasking-manager/blob/develop/LICENSE.txt"
+      "licenseURL": "https://github.com/hotosm/tasking-manager/blob/develop/LICENSE.txt"
     }
   ],
   "website": "https://tasks.hotosm.org/",

--- a/products/if-me.json
+++ b/products/if-me.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/ifmeorg/ifme/blob/master/LICENSE.txt"
+      "licenseURL": "https://github.com/ifmeorg/ifme/blob/master/LICENSE.txt"
     }
   ],
   "website": "",

--- a/products/inasafe.json
+++ b/products/inasafe.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/inasafe/inasafe/blob/develop/LICENSE.txt"
+      "licenseURL": "https://github.com/inasafe/inasafe/blob/develop/LICENSE.txt"
     }
   ],
   "website": "",

--- a/products/infagram.json
+++ b/products/infagram.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-2.0",
-      "link": "https://github.com/publiclab/infragram/blob/main/LICENSE"
+      "licenseURL": "https://github.com/publiclab/infragram/blob/main/LICENSE"
     }
   ],
   "website": "http://infragram.org/",

--- a/products/intake.json
+++ b/products/intake.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MIT",
-      "link": "https://github.com/codeforamerica/intake/blob/develop/LICENSE"
+      "licenseURL": "https://github.com/codeforamerica/intake/blob/develop/LICENSE"
     }
   ],
   "website": "https://www.clearmyrecord.org/",

--- a/products/intelehealth-android.json
+++ b/products/intelehealth-android.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MPL-2.0",
-      "link": "https://github.com/Intelehealth/Android-Mobile-Client/blob/master/License.md"
+      "licenseURL": "https://github.com/Intelehealth/Android-Mobile-Client/blob/master/License.md"
     }
   ],
   "website": "",

--- a/products/intelehealth-openmrs-ui.json
+++ b/products/intelehealth-openmrs-ui.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "MPL-2.0",
-      "link": "https://github.com/Intelehealth/intelehealth-openmrs-ui/blob/master/LICENSE"
+      "licenseURL": "https://github.com/Intelehealth/intelehealth-openmrs-ui/blob/master/LICENSE"
     }
   ],
   "website": "",

--- a/products/justfix-nyc-webapp.json
+++ b/products/justfix-nyc-webapp.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "link": "https://github.com/JustFixNYC/tenants/blob/master/LICENSE.md"
+      "licenseURL": "https://github.com/JustFixNYC/tenants/blob/master/LICENSE.md"
     }
   ],
   "website": "https://beta.justfix.nyc",

--- a/products/primero.json
+++ b/products/primero.json
@@ -4,7 +4,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "link": "https://github.com/primeroIMS/primero/blob/maint_1.6/LICENSE"
+      "licenseURL": "https://github.com/primeroIMS/primero/blob/maint_1.6/LICENSE"
     }
   ],
   "website": "https://www.primero.org/",


### PR DESCRIPTION
Changes the `license -> link` field to `license -> licenceURL` that was not properly set in PRs #5, #7, #14 and #15