### PR TITLE
MAINT: https upgrades in links

### DIFF
--- a/products/african-storybook.json
+++ b/products/african-storybook.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/atix-labs.json
+++ b/products/atix-labs.json
@@ -1,7 +1,7 @@
 {
   "name": "Atix Labs",
   "description": "Matching social enterprises to impact financing using smart contracts on blockchain technology",
-  "website": "www.circlesofangels.com",
+  "website": "https://www.circlesofangels.com",
   "license": [
     {
       "spdx": "GPL-3.0",

--- a/products/avyantra-health-technologies.json
+++ b/products/avyantra-health-technologies.json
@@ -1,7 +1,7 @@
 {
   "name": "Avyantra Health Technologies",
   "description": "Helping the diagnosis of infants affected by neonatal sepsis using machine learning",
-  "website": "www.avyantra.com",
+  "website": "https://www.avyantra.com",
   "license": [
     {
       "spdx": "GPL-3.0",

--- a/products/book-dash.json
+++ b/products/book-dash.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/british-columbia-open-textbook-collection.json
+++ b/products/british-columbia-open-textbook-collection.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/child-growth-monitor-machine-learning.json
+++ b/products/child-growth-monitor-machine-learning.json
@@ -12,6 +12,10 @@
     [
       2,
       "Zero Hunger"
+    ],
+    [
+      3,
+      "Good Health and Well-Being"
     ]
   ],
   "sectors": [],

--- a/products/child-growth-monitor.json
+++ b/products/child-growth-monitor.json
@@ -12,6 +12,10 @@
     [
       2,
       "Zero Hunger"
+    ],
+    [
+      3,
+      "Good Health and Well-Being"
     ]
   ],
   "sectors": [],

--- a/products/cireha.json
+++ b/products/cireha.json
@@ -21,7 +21,7 @@
   "sectors": [],
   "type": [
     "software",
-    "data"
+    "content"
   ],
   "repositoryURL": "https://github.com/cboard-org/cboard",
   "organizations": [

--- a/products/ck-12.json
+++ b/products/ck-12.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/conative-labs.json
+++ b/products/conative-labs.json
@@ -18,7 +18,7 @@
   "type": [
     "software"
   ],
-  "repositoryURL": "https://github.com/conative-labs/",
+  "repositoryURL": "https://github.com/conative-labs/Platform-API",
   "organizations": [
     {
       "name": "UNICEF Ventures Fund",

--- a/products/curriki.json
+++ b/products/curriki.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/digital-literacy-library.json
+++ b/products/digital-literacy-library.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/ekitabu.json
+++ b/products/ekitabu.json
@@ -1,6 +1,6 @@
 {
   "name": "eKitabu",
-  "description": "Personalized 'e-ereading and learning app for children with disabilities",
+  "description": "Personalized e-reading and learning app for children with disabilities",
   "website": "https://www.ekitabu.com",
   "license": [
     {

--- a/products/fundza-novels.json
+++ b/products/fundza-novels.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/global-digital-library.json
+++ b/products/global-digital-library.json
@@ -24,7 +24,7 @@
   "sectors": [],
   "type": [
     "software",
-    "data"
+    "content"
   ],
   "repositoryURL": "https://github.com/GlobalDigitalLibraryio/book-api",
   "organizations": [

--- a/products/imisi3d.json
+++ b/products/imisi3d.json
@@ -1,7 +1,7 @@
 {
   "name": "Imisi3D",
   "description": "Locally tailored interactve VR content to transform education in Nigeria",
-  "website": "www.imisi3d.com",
+  "website": "https://www.imisi3d.com",
   "license": [
     {
       "spdx": "GPL-3.0",

--- a/products/jhsph-opencourseware.json
+++ b/products/jhsph-opencourseware.json
@@ -20,7 +20,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/ka-lite.json
+++ b/products/ka-lite.json
@@ -20,7 +20,8 @@
   ],
   "sectors": [],
   "type": [
-    "software"
+    "software",
+    "content"
   ],
   "repositoryURL": "https://github.com/learningequality/ka-lite",
   "organizations": [

--- a/products/khan-academy.json
+++ b/products/khan-academy.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/mit-opencourseware.json
+++ b/products/mit-opencourseware.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/mobile-technology-for-community-health.json
+++ b/products/mobile-technology-for-community-health.json
@@ -29,7 +29,7 @@
   "type": [
     "software"
   ],
-  "repositoryURL": "https://github.com/motech/MOTECH",
+  "repositoryURL": "https://github.com/motech/motech",
   "organizations": [
     {
       "name": "MOTECH",

--- a/products/muckrock.json
+++ b/products/muckrock.json
@@ -1,6 +1,6 @@
 {
   "name": "Muckrock",
-  "description": "Muckrock source code",
+  "description": "A non-profit collaborative news site that gives you the tools to keep our government transparent and accountable.",
   "website": "",
   "license": [
     {

--- a/products/nominatim.json
+++ b/products/nominatim.json
@@ -5,7 +5,7 @@
   "license": [
     {
       "spdx": "GPL-2.0",
-      "licenseURL": "https://github.com/openstreetmap/Nominatim/blob/master/COPYING"
+      "licenseURL": "https://github.com/osm-search/Nominatim/blob/master/COPYING"
     }
   ],
   "SDGs": [
@@ -18,7 +18,7 @@
   "type": [
     "software"
   ],
-  "repositoryURL": "https://github.com/openstreetmap/Nominatim",
+  "repositoryURL": "https://github.com/osm-search/Nominatim",
   "organizations": [
     {
       "name": "Open Street Map",

--- a/products/nubian.json
+++ b/products/nubian.json
@@ -1,7 +1,7 @@
 {
   "name": "Nubian",
   "description": "Learning content built in WebXR, adpated to the local context of the school system in Ghana",
-  "website": "www.nubianvr.com",
+  "website": "https://www.nubianvr.com",
   "license": [
     {
       "spdx": "MIT",

--- a/products/oer-africa.json
+++ b/products/oer-africa.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/oer-commons.json
+++ b/products/oer-commons.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/open-ag-data-alliance.json
+++ b/products/open-ag-data-alliance.json
@@ -29,7 +29,8 @@
   "sectors": [],
   "type": [
     "software",
-    "data"
+    "data",
+    "content"
   ],
   "organizations": [
     {

--- a/products/open-civil-registration-and-vital-statistics.json
+++ b/products/open-civil-registration-and-vital-statistics.json
@@ -4,7 +4,7 @@
     "OpenCRVS"
   ],
   "description": "Configurable software for civil registration designed for low resource settings",
-  "website": "www.opencrvs.org",
+  "website": "https://www.opencrvs.org",
   "license": [
     {
       "spdx": "MPL-2.0",

--- a/products/open-demographics.json
+++ b/products/open-demographics.json
@@ -16,7 +16,8 @@
   ],
   "sectors": [],
   "type": [
-    "software"
+    "content",
+    "data"
   ],
   "repositoryURL": "https://github.com/drnikki/open-demographics",
   "organizations": [

--- a/products/open-stax.json
+++ b/products/open-stax.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/open-textbook-library.json
+++ b/products/open-textbook-library.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/open-up-resources.json
+++ b/products/open-up-resources.json
@@ -17,7 +17,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/openfarm.json
+++ b/products/openfarm.json
@@ -25,7 +25,8 @@
   "sectors": [],
   "type": [
     "software",
-    "data"
+    "data",
+    "content"
   ],
   "repositoryURL": "https://github.com/openfarmcc/OpenFarm",
   "organizations": [

--- a/products/openlearn.json
+++ b/products/openlearn.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/openstates.json
+++ b/products/openstates.json
@@ -5,7 +5,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "licenseURL": "https://github.com/openstates/openstates/blob/master/LICENSE"
+      "licenseURL": "https://github.com/openstates/openstates-scrapers/blob/master/LICENSE"
     }
   ],
   "SDGs": [
@@ -18,7 +18,7 @@
   "type": [
     "software"
   ],
-  "repositoryURL": "https://github.com/openstates/openstates",
+  "repositoryURL": "https://github.com/openstates/openstates-scrapers",
   "organizations": [
     {
       "name": "Open States",

--- a/products/pharmadex.json
+++ b/products/pharmadex.json
@@ -10,6 +10,10 @@
   ],
   "SDGs": [
     [
+      3,
+      "Good Health and Well-Being"
+    ],
+    [
       16,
       "Peace, Justice and Strong Institutions"
     ],

--- a/products/phet-interactive-simulations.json
+++ b/products/phet-interactive-simulations.json
@@ -28,7 +28,8 @@
   "sectors": [],
   "type": [
     "software",
-    "data"
+    "data",
+    "content"
   ],
   "organizations": [
     {

--- a/products/planwise.json
+++ b/products/planwise.json
@@ -10,6 +10,10 @@
   ],
   "SDGs": [
     [
+      3,
+      "Good Health and Well-Being"
+    ],
+    [
       16,
       "Peace, Justice and Strong Institutions"
     ],

--- a/products/practical-plants.json
+++ b/products/practical-plants.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/saylor-academy.json
+++ b/products/saylor-academy.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/scratch-blocks.json
+++ b/products/scratch-blocks.json
@@ -1,6 +1,6 @@
 {
   "name": "Scratch Blocks",
-  "description": "Scratch Blocks is a library for building creative computing interfaces. ",
+  "description": "Scratch Blocks is a library for building creative computing interfaces. Scratch helps young people learn to think creatively, reason systematically, and work collaboratively — essential skills for life in the 21st century.",
   "website": "",
   "license": [
     {

--- a/products/scratch-gui.json
+++ b/products/scratch-gui.json
@@ -1,6 +1,6 @@
 {
   "name": "Scratch GUI",
-  "description": "Graphical User Interface for creating and running Scratch 3.0 projects.",
+  "description": "Graphical User Interface for creating and running Scratch 3.0 projects. Scratch helps young people learn to think creatively, reason systematically, and work collaboratively — essential skills for life in the 21st century.",
   "website": "",
   "license": [
     {

--- a/products/scratch-vm.json
+++ b/products/scratch-vm.json
@@ -1,6 +1,6 @@
 {
   "name": "Scratch VM",
-  "description": "Virtual Machine used to represent, run, and maintain the state of programs for Scratch 3.0",
+  "description": "Virtual Machine used to represent, run, and maintain the state of programs for Scratch 3.0. Scratch helps young people learn to think creatively, reason systematically, and work collaboratively — essential skills for life in the 21st century.",
   "website": "",
   "license": [
     {

--- a/products/scratch-web.json
+++ b/products/scratch-web.json
@@ -1,6 +1,6 @@
 {
   "name": "Scratch Web",
-  "description": "Standalone web client for Scratch ",
+  "description": "Standalone web client for Scratch. Scratch helps young people learn to think creatively, reason systematically, and work collaboratively — essential skills for life in the 21st century.",
   "website": "https://scratch.mit.edu",
   "license": [
     {

--- a/products/sf-dahlia.json
+++ b/products/sf-dahlia.json
@@ -5,7 +5,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "licenseURL": "https://github.com/Exygy/sf-dahlia-web/blob/master/LICENSE.md"
+      "licenseURL": "https://github.com/SFDigitalServices/sf-dahlia-web/blob/master/LICENSE.md"
     }
   ],
   "SDGs": [
@@ -18,7 +18,7 @@
   "type": [
     "software"
   ],
-  "repositoryURL": "https://github.com/Exygy/sf-dahlia-web",
+  "repositoryURL": "https://github.com/SFDigitalServices/sf-dahlia-web",
   "organizations": [
     {
       "name": "Exygy",

--- a/products/skillscommons.json
+++ b/products/skillscommons.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/storyweaver.json
+++ b/products/storyweaver.json
@@ -16,7 +16,7 @@
   ],
   "sectors": [],
   "type": [
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/wikihow.json
+++ b/products/wikihow.json
@@ -21,7 +21,7 @@
   "sectors": [],
   "type": [
     "software",
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/products/wikipedia.json
+++ b/products/wikipedia.json
@@ -17,7 +17,7 @@
   "sectors": [],
   "type": [
     "software",
-    "data"
+    "content"
   ],
   "organizations": [
     {

--- a/scripts/order-fields.js
+++ b/scripts/order-fields.js
@@ -29,7 +29,9 @@ const propertiesOrder = [
   "organizations",
   "name",
   "website",
-  "org_type"
+  "org_type",
+  "contact_name",
+  "contact_email"
 ];
 
 let fix = false;
@@ -62,6 +64,9 @@ glob("*.json", { cwd: productsPath }, async (err, productFiles) => {
       // upgrade to HTTPS :)
       if (product.hasOwnProperty("website")) {
         product["website"] = product["website"].replace(/http:/g, "https:");
+        if(product['website'] != '' && ! product['website'].match('https://')){
+          product['website'] = 'https://' + product['website']
+        }
       }
       if (product.hasOwnProperty("repositoryURL")) {
         product["repositoryURL"] = product["repositoryURL"].replace(
@@ -99,7 +104,7 @@ glob("*.json", { cwd: productsPath }, async (err, productFiles) => {
     } else {
       if (JSON.stringify(product, propertiesOrder, 2) != jsonData) {
         console.log(
-          "JSON properties not in the expected order for" +
+          "JSON properties not in the expected order for " +
             productFiles[i] +
             ". Re-run with --fix to fix."
         );


### PR DESCRIPTION
Bringing this repo in sync with [unicef/publicgoods-candidates](https://github.com/unicef/publicgoods-candidates). 

This PR reclassifies many products as `content` following publicgoods/data-schema#6, and upgrades many links to `https://`. It also adjusts some of the CI scripts to account for additional pre-agreed fields that hadn't been used until now (and thus the CI would provide a false fail).