### PR TITLE
BLD: added nominees from pandemic-response-repo

### DIFF
--- a/products/2019-ncov-data-repository-by-johns-hopkins-csse.json
+++ b/products/2019-ncov-data-repository-by-johns-hopkins-csse.json
@@ -1,0 +1,28 @@
+{
+  "name": "2019-nCoV Data Repository by Johns Hopkins CSSE",
+  "description": "This is the data repository for the 2019 Novel Coronavirus Visual Dashboard operated by the Johns Hopkins University Center for Systems Science and Engineering (JHU CSSE). It is also supported by the ESRI Living Atlas Team and the Johns Hopkins University Applied Physics Lab (JHU APL).",
+  "website": "https://www.arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6",
+  "license": [
+    {
+      "spdx": "CC-BY-4.0",
+      "licenseURL": "https://github.com/CSSEGISandData/COVID-19/blob/master/README.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/CSSEGISandData/COVID-19",
+  "organizations": [
+    {
+      "name": "Johns Hopkins University",
+      "org_type": "owner",
+      "contact_email": "jhusystems@gmail.com"
+    }
+  ]
+}

--- a/products/2019-ncov-data-repository-by-johns-hopkins-csse.json
+++ b/products/2019-ncov-data-repository-by-johns-hopkins-csse.json
@@ -15,7 +15,7 @@
     ]
   ],
   "type": [
-    "software"
+    "data"
   ],
   "repositoryURL": "https://github.com/CSSEGISandData/COVID-19",
   "organizations": [

--- a/products/aarogya-setu.json
+++ b/products/aarogya-setu.json
@@ -1,0 +1,28 @@
+{
+  "name": "Aarogya Setu",
+  "description": "Aarogya Setu is a mobile application developed by the Government of India to connect essential health services with the people of India in our combined fight against COVID-19.",
+  "website": "https://www.aarogyasetu.gov.in/",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/nic-delhi/AarogyaSetu_Android/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/nic-delhi/AarogyaSetu_Android",
+  "organizations": [
+    {
+      "name": "The Government of India's Ministry of Electronics and Information Technology",
+      "org_type": "owner",
+      "contact_email": "support.aarogyasetu@nic.in"
+    }
+  ]
+}

--- a/products/care.json
+++ b/products/care.json
@@ -1,0 +1,27 @@
+{
+  "name": "Care",
+  "description": "Care is a single point to link hospitals, Corona Care Centers and volunteers to the unified Corona Safe Network so that the Kerala Chief Minister's Office has direct access to live reports of hospital admittances to prevent overloading the healthcare system capacity.",
+  "website": "https://care.coronasafe.network/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/coronasafe/care/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/coronasafe/care",
+  "organizations": [
+    {
+      "name": "Kerala State Disaster Management Authority",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/cdc-covid-19-health-bot.json
+++ b/products/cdc-covid-19-health-bot.json
@@ -4,7 +4,7 @@
   "website": "https://github.com/CDCgov/covid19healthbot",
   "license": [
     {
-      "spdx": "CCO-1.0",
+      "spdx": "CC0-1.0",
       "licenseURL": "https://github.com/CDCgov/covid19healthbot/blob/master/README.md"
     }
   ],

--- a/products/cdc-covid-19-health-bot.json
+++ b/products/cdc-covid-19-health-bot.json
@@ -1,0 +1,27 @@
+{
+  "name": "CDC COVID-19 Health Bot",
+  "description": "This project collects automated screening protocols and self-checker algorithms from organizations implementing CDC screening protocols in interactive web sites, chat bots, and other technology.",
+  "website": "https://github.com/CDCgov/covid19healthbot",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/CDCgov/covid19healthbot/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/CDCgov/covid19healthbot",
+  "organizations": [
+    {
+      "name": "Center for Disease Control",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/cdc-covid-19-health-bot.json
+++ b/products/cdc-covid-19-health-bot.json
@@ -4,8 +4,8 @@
   "website": "https://github.com/CDCgov/covid19healthbot",
   "license": [
     {
-      "spdx": "Apache-2.0",
-      "licenseURL": "https://github.com/CDCgov/covid19healthbot/blob/master/LICENSE"
+      "spdx": "CCO-1.0",
+      "licenseURL": "https://github.com/CDCgov/covid19healthbot/blob/master/README.md"
     }
   ],
   "SDGs": [
@@ -15,7 +15,7 @@
     ]
   ],
   "type": [
-    "software"
+    "data"
   ],
   "repositoryURL": "https://github.com/CDCgov/covid19healthbot",
   "organizations": [

--- a/products/common-forms-toolkit.json
+++ b/products/common-forms-toolkit.json
@@ -1,0 +1,30 @@
+{
+  "name": "Common Forms Toolkit",
+  "aliases": [
+    "COMFORT"
+  ],
+  "description": "COMFORT is an opinionated toolkit approach to designing and managing multi-tenanted forms. The Government of British Columbia is using this software to create screening forms that protect employees, contractors, and employers by ensuring a safe workplace and demonstrating proof of an Infection Prevention Control protocol (IPCP).",
+  "website": "https://silviculture-ipc-dev.pathfinder.gov.bc.ca/app/#/home",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/bcgov/common-forms-toolkit/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/bcgov/common-forms-toolkit",
+  "organizations": [
+    {
+      "name": "Government of British Columbia",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/corona-warn-app-android.json
+++ b/products/corona-warn-app-android.json
@@ -1,0 +1,28 @@
+{
+  "name": "Corona Warn App - Android",
+  "description": "The Corona-Warn-App is an app that helps trace infection chains of SARS-CoV-2 (which can cause COVID-19) in Germany. The app is based on technologies with a decentralized approach and notifies users if they have been exposed to SARS-CoV-2.",
+  "website": "https://coronawarn.app",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/corona-warn-app/cwa-app-android/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/corona-warn-app/cwa-app-android",
+  "organizations": [
+    {
+      "name": "Deutsche Telekom and SAP",
+      "org_type": "owner",
+      "contact_email": "corona-warn-app.opensource@sap.com"
+    }
+  ]
+}

--- a/products/corona-warn-app-ios.json
+++ b/products/corona-warn-app-ios.json
@@ -1,0 +1,33 @@
+{
+  "name": "Corona Warn App - iOS",
+  "description": "The Corona-Warn-App is an app that helps trace infection chains of SARS-CoV-2 (which can cause COVID-19) in Germany. The app is based on technologies with a decentralized approach and notifies users if they have been exposed to SARS-CoV-2.",
+  "website": "https://coronawarn.app",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/corona-warn-app/cwa-app-ios/blob/develop/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/corona-warn-app/cwa-app-ios",
+  "organizations": [
+    {
+      "name": "SAP",
+      "org_type": "owner",
+      "contact_email": "corona-warn-app.opensource@sap.com"
+    },
+    {
+      "name": "Deutsche Telekom",
+      "org_type": "owner",
+      "contact_email": "corona-warn-app.opensource@sap.com"
+    }
+  ]
+}

--- a/products/coronavirus-service-directory.json
+++ b/products/coronavirus-service-directory.json
@@ -1,0 +1,28 @@
+{
+  "name": "Coronavirus Service Directory",
+  "description": "A simple directory of services that can help residents cope if they're staying at home due to the coronavirus pandemic.",
+  "website": "https://coronavirus-help.camden.gov.uk/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/wearefuturegov/coronavirus-service-directory/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/wearefuturegov/coronavirus-service-directory",
+  "organizations": [
+    {
+      "name": "FutureGov",
+      "org_type": "owner",
+      "contact_email": "hello@wearefuturegov.com"
+    }
+  ]
+}

--- a/products/covid-19-algorithme-orientation.json
+++ b/products/covid-19-algorithme-orientation.json
@@ -1,0 +1,28 @@
+{
+  "name": "COVID-19 Algorithme Orientation",
+  "description": "A referral tool to support residents to determine whether they are experiencing symptoms of COVID-19. The tool asks users to respond to a series of questions about their symptoms and provides relevant information and recommendations.",
+  "website": "https://delegation-numerique-en-sante.github.io/covid19-algorithme-orientation/",
+  "license": [
+    {
+      "spdx": "EPL-2.0",
+      "licenseURL": "https://github.com/Delegation-numerique-en-sante/covid19-algorithme-orientation/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/Delegation-numerique-en-sante/covid19-algorithme-orientation",
+  "organizations": [
+    {
+      "name": "The French Ministry of Social Affairs and Health",
+      "org_type": "owner",
+      "contact_email": "mobilisation-covid@sante.gouv.fr"
+    }
+  ]
+}

--- a/products/covid-19-benefits.json
+++ b/products/covid-19-benefits.json
@@ -1,0 +1,28 @@
+{
+  "name": "COVID-19 Benefits",
+  "description": "This product helps Canadians find existing and new individual benefits relevant to COVID-19. Users can anonymously answer a few simple questions to get a personalized list of benefits that could help them, and calculate how much financial assistance users may be eligible for and when it might be delivered.",
+  "website": "https://covid-benefits.alpha.canada.ca/en/start",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/cds-snc/c19-benefits-node/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/cds-snc/c19-benefits-node/",
+  "organizations": [
+    {
+      "name": "Canadian Digital Service",
+      "org_type": "owner",
+      "contact_email": "cds-snc@tbs-sct.gc.ca"
+    }
+  ]
+}

--- a/products/covid-19-data-repository-for-south-africa.json
+++ b/products/covid-19-data-repository-for-south-africa.json
@@ -1,0 +1,33 @@
+{
+  "name": "COVID-19 Data Repository for South Africa",
+  "description": "Researchers from the University of Pretoria collected and collated data from the South African Department of Health [DoH] and National Institute for Communicable Diseases [NICD] statements and alerts and built a dashboard being used by the Western Cape, the City of Cape Town, and the Gauteng Provincial Government.",
+  "website": "https://bitly.com/covid19za-dash",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/dsfsi/covid19za/blob/master/LICENSE"
+    },
+    {
+      "spdx": "CC-BY-4.0",
+      "licenseURL": "https://github.com/dsfsi/covid19za/blob/master/README.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software",
+    "data"
+  ],
+  "repositoryURL": "https://github.com/dsfsi/covid19za",
+  "organizations": [
+    {
+      "name": "University of Pretoria",
+      "org_type": "owner",
+      "contact_email": "vukosi.marivate@cs.up.ac.za"
+    }
+  ]
+}

--- a/products/covid-19-emergency-assistance-programs.json
+++ b/products/covid-19-emergency-assistance-programs.json
@@ -1,0 +1,27 @@
+{
+  "name": "COVID-19 Emergency Assistance Programs",
+  "description": "This is a beta version Eligibility Wizard that focuses on newly announced State Emergency Assistance programs and the SBA disaster loan program. It is currently used by the State of New Jersey, and will be updated regularly as new federal, state, local, and philanthropic programs become available.",
+  "website": "https://assistance.business.nj.gov/",
+  "license": [
+    {
+      "spdx": "CC0-1.0",
+      "licenseURL": "https://github.com/usdigitalresponse/small-business-programs/blob/latest/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/usdigitalresponse/small-business-programs",
+  "organizations": [
+    {
+      "name": "US Digital Response",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covid-19-employee-screening-tool.json
+++ b/products/covid-19-employee-screening-tool.json
@@ -1,0 +1,27 @@
+{
+  "name": "COVID-19 Employee Screening Tool",
+  "description": "A tool for screening employees when entering and leaving a location.",
+  "website": "https://github.com/code-for-canada/covid19-employee-screening-tool",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/code-for-canada/covid19-employee-screening-tool/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/code-for-canada/covid19-employee-screening-tool",
+  "organizations": [
+    {
+      "name": "Code for Canada",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covid-19-hospital-impact-model-for-epidemics.json
+++ b/products/covid-19-hospital-impact-model-for-epidemics.json
@@ -1,0 +1,30 @@
+{
+  "name": "COVID-19 Hospital Impact Model for Epidemics",
+  "aliases": [
+    "CHIME"
+  ],
+  "description": "The CHIME (COVID-19 Hospital Impact Model for Epidemics) Application is designed to assist hospitals and public health officials with understanding hospital capacity needs as they relate to the COVID pandemic.",
+  "website": "https://penn-chime.phl.io/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/CodeForPhilly/chime/blob/develop/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/CodeForPhilly/chime",
+  "organizations": [
+    {
+      "name": "Penn Medicine",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covid-19-incarceration-model.json
+++ b/products/covid-19-incarceration-model.json
@@ -1,0 +1,28 @@
+{
+  "name": "COVID-19 Incarceration Model",
+  "description": "An interactive model to allow criminal justice leaders and their staff to project the likely impact of COVID-19 within facilities.",
+  "website": "https://www.recidiviz.org/covid",
+  "license": [
+    {
+      "spdx": "GPL-3.0",
+      "licenseURL": "https://docs.google.com/spreadsheets/d/e/2PACX-1vQ60fTTBlezKwvppNT8_wy8r4zWnx8-u6pkrwwloZ1hQwwFbobEZz7O1mOKSa2ph7YOlvMMT9oWDzAc/pub#"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "data"
+  ],
+  "repositoryURL": "https://docs.google.com/spreadsheets/d/e/2PACX-1vQ60fTTBlezKwvppNT8_wy8r4zWnx8-u6pkrwwloZ1hQwwFbobEZz7O1mOKSa2ph7YOlvMMT9oWDzAc/pub#",
+  "organizations": [
+    {
+      "name": "Recidiviz",
+      "org_type": "owner",
+      "contact_email": "covid@recidiviz.org"
+    }
+  ]
+}

--- a/products/covid-19-projections.json
+++ b/products/covid-19-projections.json
@@ -1,0 +1,27 @@
+{
+  "name": "COVID-19 Projections",
+  "description": "COVID-19 prediction model that uses AI and classic infections disease modeling to simulate the outbreak in each country, state, and region. It is the only model shared by the CDC that is not publicly funded, and factors in regional re-openings in their projections.",
+  "website": "https://covid19-projections.com/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/youyanggu/covid19_projections/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/youyanggu/covid19_projections",
+  "organizations": [
+    {
+      "name": "Youyang Gu",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covid-19-projections.json
+++ b/products/covid-19-projections.json
@@ -15,7 +15,7 @@
     ]
   ],
   "type": [
-    "software"
+    "data"
   ],
   "repositoryURL": "https://github.com/youyanggu/covid19_projections",
   "organizations": [

--- a/products/covid-19-remote-monitoring-platform.json
+++ b/products/covid-19-remote-monitoring-platform.json
@@ -1,0 +1,28 @@
+{
+  "name": "COVID-19 Remote Monitoring Platform",
+  "description": "A patient self-monitoring tool to help healthcare systems monitor COVID patients remotely using text-based follow up. It is currently deployed at 29 hospitals in Grant Est region of France.",
+  "website": "https://blog.lifen.fr/posts/covid-19-une-application-pour-diagnostiquer-les-patients-depuis-leur-domicile",
+  "license": [
+    {
+      "spdx": "AGPL-3.0",
+      "licenseURL": "https://github.com/lifen-labs/covid/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/lifen-labs/covid",
+  "organizations": [
+    {
+      "name": "Lifen Labs",
+      "org_type": "owner",
+      "contact_email": "covid19@lifen.fr"
+    }
+  ]
+}

--- a/products/covid-19-scenarios.json
+++ b/products/covid-19-scenarios.json
@@ -1,0 +1,27 @@
+{
+  "name": "COVID-19 Scenarios",
+  "description": "This tool explores the dynamics of COVID-19 cases and the associated strain on the healthcare system in the near future. It is currently being used by Swiss authorities.",
+  "website": "https://covid19-scenarios.org/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/neherlab/covid19_scenarios/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/neherlab/covid19_scenarios",
+  "organizations": [
+    {
+      "name": "University of Basel",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covid-19-self-assessment-tool.json
+++ b/products/covid-19-self-assessment-tool.json
@@ -1,0 +1,27 @@
+{
+  "name": "COVID-19 Self Assessment Tool",
+  "description": "The questionnaire takes the public through a series of questions to inform those who are concerned they may have contracted COVID-19.",
+  "website": "https://covid-19.ontario.ca/self-assessment/#q0",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/ongov/covid-19-self-assessment/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/ongov/covid-19-self-assessment",
+  "organizations": [
+    {
+      "name": "Ontario Government",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covid-act-now.json
+++ b/products/covid-act-now.json
@@ -1,0 +1,28 @@
+{
+  "name": "COVID Act Now",
+  "description": "This tool is built to enable political leaders to quickly make decisions in their Coronavirus response informed by best available data and modeling. COVID Act Now has worked to estimate the ICU facility capacity for public health offices in Michigan, Kentucky and other state and local governments.",
+  "website": "https://covidactnow.org/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/covid-projections/covid-projections/blob/develop/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/covid-projections/covid-projections",
+  "organizations": [
+    {
+      "name": "Covid ActNow",
+      "org_type": "owner",
+      "contact_email": "jonathan@covidactnow.org"
+    }
+  ]
+}

--- a/products/covid-alert-mobile-app.json
+++ b/products/covid-alert-mobile-app.json
@@ -1,0 +1,28 @@
+{
+  "name": "COVID Alert Mobile App",
+  "description": "This repository implements a React Native client application for Apple/Google's Exposure Notification framework, informed by the guidance provided by Canada's Privacy Commissioners. For more information on how this all works, read through the COVID Shield Rationale. COVID Shield was originally developed by volunteers at Shopify and in partnership with Health Canada, the Public Health Agency of Canada, Innovation, Science and Economic Development Canada, the Canadian Centre for Cyber Security, and the Ontario Digital Service.",
+  "website": "https://github.com/cds-snc/covid-alert-app",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/cds-snc/covid-alert-app/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/cds-snc/covid-alert-app",
+  "organizations": [
+    {
+      "name": "Canadian Digital Service",
+      "org_type": "owner",
+      "contact_email": "cds-snc@tbs-sct.gc.ca"
+    }
+  ]
+}

--- a/products/covid-caremap.json
+++ b/products/covid-caremap.json
@@ -1,0 +1,28 @@
+{
+  "name": "Covid CareMap",
+  "description": "Covid Care Map helps with mapping existing and forecasted health system capacity gaps (beds, staffing, ventilators, supplies) to care for surging numbers of COVID-19 patients (especially those requiring intensive care) with granular detail. It organizes data for other apps such as COVID Act Now, which has worked with public health authorities at the state and municipal level to project facility bed estimates.",
+  "website": "https://www.covidcaremap.org",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/covidcaremap/covid19-healthsystemcapacity/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/covidcaremap/covid19-healthsystemcapacity",
+  "organizations": [
+    {
+      "name": "Covid Care Map",
+      "org_type": "owner",
+      "contact_email": "dave@covidcaremap.org"
+    }
+  ]
+}

--- a/products/covid-safe-paths.json
+++ b/products/covid-safe-paths.json
@@ -1,0 +1,28 @@
+{
+  "name": "COVID Safe Paths",
+  "description": "COVID Safe Paths (based on Private Kit) is an open and privacy preserving system to use personal information to battle COVID.",
+  "website": "https://covidsafepaths.org",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/Path-Check/covid-safe-paths/blob/develop/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/tripleblindmarket/covid-safe-paths",
+  "organizations": [
+    {
+      "name": "MIT",
+      "org_type": "owner",
+      "contact_email": "privatekit@media.mit.edu"
+    }
+  ]
+}

--- a/products/covid-tracking-data.json
+++ b/products/covid-tracking-data.json
@@ -1,0 +1,27 @@
+{
+  "name": "COVID Tracking Data",
+  "description": "This project collects information from 50 state-level public health authorities, the District of Columbia, and 5 other US territories to provide the most comprehensive testing data we can collect for the novel coronavirus, SARS-CoV-2.",
+  "website": "https://covidtracking.com/",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/COVID19Tracking/covid-tracking-data/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "data"
+  ],
+  "repositoryURL": "https://github.com/COVID19Tracking/covid-tracking-data",
+  "organizations": [
+    {
+      "name": "The Atlantic, Related Sciences",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covid19canada.json
+++ b/products/covid19canada.json
@@ -1,0 +1,28 @@
+{
+  "name": "Covid19Canada",
+  "description": "Researchers at the University of Toronto, responding to the critical need for timely, accurate, and accessible data on COVID-19 cases, developed an individual-level dataset of Canadian COVID-19 cases. These figures, which include mortalities, recoveries, and testing, are collected from news reports and government health authorities and then manually entered by the research team.",
+  "website": "https://art-bd.shinyapps.io/covid19canada/",
+  "license": [
+    {
+      "spdx": "CC-BY-4.0",
+      "licenseURL": "https://github.com/ishaberry/Covid19Canada/blob/master/LICENSE.MD"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "data"
+  ],
+  "repositoryURL": "https://github.com/ishaberry/Covid19Canada",
+  "organizations": [
+    {
+      "name": "COVID-19 Canada Open Data Working Group",
+      "org_type": "owner",
+      "contact_email": "isha.berry@mail.utoronto.ca"
+    }
+  ]
+}

--- a/products/covidbot.json
+++ b/products/covidbot.json
@@ -1,0 +1,27 @@
+{
+  "name": "Covidbot",
+  "description": "The Pasteur Institute, Greater Paris University Hospitals, and the chatbot start-up Clevy created a questionnaire that individuals can use to assess their risk of COVID-19 infection. The form has 23 questions on possible symptoms, medical history, age, and other physical attributes. If a user is deemed a high risk from their responses, they are redirected to emergency services while a suspect case is redirected to telemedicine services.",
+  "website": "https://www.covidbot.fr/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/CSML-by-Clevy/covidbot-autodiagnostic/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/CSML-by-Clevy/covidbot-autodiagnostic",
+  "organizations": [
+    {
+      "name": "The Pasteur Institute",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/covidsafe.json
+++ b/products/covidsafe.json
@@ -1,0 +1,28 @@
+{
+  "name": "CovidSafe",
+  "description": "Doctors and researchers at the University of Washington, in partnership with Microsoft volunteers and the Office of Governor Jay Inslee, are developing a tool to alert residents about highly relevant public health announcements, potential exposure to COVID-19, and to assist public health officials and contact tracing teams without compromising personal privacy.",
+  "website": "https://covidsafe.cs.washington.edu/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/covidsafe/App-Android/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/covidsafe/App-Android",
+  "organizations": [
+    {
+      "name": "University of Washington",
+      "org_type": "owner",
+      "contact_email": "covidsafe@uw.edu"
+    }
+  ]
+}

--- a/products/dati-covid-19-italia.json
+++ b/products/dati-covid-19-italia.json
@@ -1,0 +1,27 @@
+{
+  "name": "Dati COVID-19 Italia",
+  "description": "Publicly available data on the spread of COVID-19 within Italy.",
+  "website": "https://opendatadpc.maps.arcgis.com/apps/opsdashboard/index.html#/b0c68bce2cce478eaac82fe38d4138b1",
+  "license": [
+    {
+      "spdx": "CC-BY-4.0",
+      "licenseURL": "https://github.com/pcm-dpc/COVID-19/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "data"
+  ],
+  "repositoryURL": "https://github.com/pcm-dpc/COVID-19",
+  "organizations": [
+    {
+      "name": "Italian Department of Civil Protection",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/digital-assister-for-michigan.json
+++ b/products/digital-assister-for-michigan.json
@@ -1,0 +1,27 @@
+{
+  "name": "Digital Assister for Michigan",
+  "description": "A multi-benefit assistance application built for the State of Michigan.",
+  "website": "https://demo.michiganbenefits.org/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/codeforamerica/michigan-benefits/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/codeforamerica/michigan-benefits",
+  "organizations": [
+    {
+      "name": "Code for America",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/enhanced-traveller-screening.json
+++ b/products/enhanced-traveller-screening.json
@@ -1,0 +1,27 @@
+{
+  "name": "Enhanced Traveller Screening",
+  "description": "A digital service built in partnership with the Ministry of Health and Service B.C. which supports British Columbians returning from out-of-country to self isolate.",
+  "website": "https://github.com/bcgov/enhanced-travel-screening",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/bcgov/enhanced-travel-screening/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/bcgov/enhanced-travel-screening",
+  "organizations": [
+    {
+      "name": "Ministry of Health and Services, Government of British Columbia",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/erouska.json
+++ b/products/erouska.json
@@ -1,5 +1,5 @@
 {
-  "name": "eRouaka",
+  "name": "erouška",
   "description": "A contact-tracing app that uses Bluetooth to record encouters of other app users in the area, and after a user tests positive for COVID-19, health authorities can ask the sick individual to submit their data to create a map of potential secondary infections.  The system architecture was inspired by Sinagpore's OpenTrace protocol and development has been approved by the Czech Ministry of Healthcare.",
   "website": "https://erouska.cz/",
   "license": [

--- a/products/erouska.json
+++ b/products/erouska.json
@@ -1,0 +1,28 @@
+{
+  "name": "eRouaka",
+  "description": "A contact-tracing app that uses Bluetooth to record encouters of other app users in the area, and after a user tests positive for COVID-19, health authorities can ask the sick individual to submit their data to create a map of potential secondary infections.  The system architecture was inspired by Sinagpore's OpenTrace protocol and development has been approved by the Czech Ministry of Healthcare.",
+  "website": "https://erouska.cz/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/covid19cz/erouska-android/blob/develop/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/covid19cz/erouska-android",
+  "organizations": [
+    {
+      "name": "COVID19CZ",
+      "org_type": "owner",
+      "contact_email": "david.vavra@erouska.cz"
+    }
+  ]
+}

--- a/products/findthemasks.json
+++ b/products/findthemasks.json
@@ -1,0 +1,28 @@
+{
+  "name": "FindTheMasks",
+  "description": "Rapid response technology to connect personal protective equipment (PPE) donations with healthcare workers in need.",
+  "website": "https://findthemasks.com/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/findthemasks/findthemasks/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/findthemasks/findthemasks",
+  "organizations": [
+    {
+      "name": "FindTheMasks",
+      "org_type": "owner",
+      "contact_email": "contact@findthemasks.com"
+    }
+  ]
+}

--- a/products/gov.uk-notify.json
+++ b/products/gov.uk-notify.json
@@ -1,0 +1,27 @@
+{
+  "name": "GOV.UK Notify",
+  "description": "Send emails, text messages and letters to users. It's been adopted by the US Department of Veterans Affairs and the Canadian Digital Service.",
+  "website": "https://www.notifications.service.gov.uk/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/alphagov/notifications-api/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/alphagov/notifications-api",
+  "organizations": [
+    {
+      "name": "The United Kingdom Government Digital Services",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/hamagen-react-native.json
+++ b/products/hamagen-react-native.json
@@ -1,0 +1,27 @@
+{
+  "name": "Hamagen React Native",
+  "description": "Israel's Ministry of Health's COVID-19 Exposure Prevention App.",
+  "website": "https://github.com/MohGovIL/hamagen-react-native",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/MohGovIL/hamagen-react-native/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/MohGovIL/hamagen-react-native",
+  "organizations": [
+    {
+      "name": "Israel's Ministry of Health",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/healthcare-rollcall.json
+++ b/products/healthcare-rollcall.json
@@ -1,0 +1,27 @@
+{
+  "name": "Healthcare Rollcall",
+  "description": "This system will provide methods for healthcare providers to check-in with public health agencies during disasters, and update their information during non-emergency periods.",
+  "website": "https://healthcarerollcall.org",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/CodeForBaltimore/Healthcare-Rollcall/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/CodeForBaltimore/Healthcare-Rollcall",
+  "organizations": [
+    {
+      "name": "Code for Baltimore",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/immuni-android.json
+++ b/products/immuni-android.json
@@ -1,0 +1,28 @@
+{
+  "name": "Immuni Android",
+  "description": "Immuni is the Italian Governments exposure notification solution, realized by the Special Commissioner for the COVID-19 emergency, in collaboration with the Ministry of Health and the Ministry for Technological Innovation and Digitalization.",
+  "website": "https://www.immuni.italia.it/",
+  "license": [
+    {
+      "spdx": "AGPL-3.0",
+      "licenseURL": "https://github.com/immuni-app/immuni-app-android/blob/development/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/immuni-app/immuni-app-android",
+  "organizations": [
+    {
+      "name": "Presidenza del Consiglio dei Ministri",
+      "org_type": "owner",
+      "contact_email": "o.cardia@me.com"
+    }
+  ]
+}

--- a/products/immuni-android.json
+++ b/products/immuni-android.json
@@ -1,6 +1,6 @@
 {
   "name": "Immuni Android",
-  "description": "Immuni is the Italian Governments exposure notification solution, realized by the Special Commissioner for the COVID-19 emergency, in collaboration with the Ministry of Health and the Ministry for Technological Innovation and Digitalization.",
+  "description": "Immuni is the Italian Government exposure notification solution, realized by the Special Commissioner for the COVID-19 emergency, in collaboration with the Ministry of Health and the Ministry for Technological Innovation and Digitalization.",
   "website": "https://www.immuni.italia.it/",
   "license": [
     {

--- a/products/immuni-ios.json
+++ b/products/immuni-ios.json
@@ -1,6 +1,6 @@
 {
   "name": "Immuni iOS",
-  "description": "Immuni is the Italian Governments exposure notification solution, realized by the Special Commissioner for the COVID-19 emergency, in collaboration with the Ministry of Health and the Ministry for Technological Innovation and Digitalization.",
+  "description": "Immuni is the Italian Government exposure notification solution, realized by the Special Commissioner for the COVID-19 emergency, in collaboration with the Ministry of Health and the Ministry for Technological Innovation and Digitalization.",
   "website": "https://www.immuni.italia.it/",
   "license": [
     {

--- a/products/immuni-ios.json
+++ b/products/immuni-ios.json
@@ -1,0 +1,28 @@
+{
+  "name": "Immuni iOS",
+  "description": "Immuni is the Italian Governments exposure notification solution, realized by the Special Commissioner for the COVID-19 emergency, in collaboration with the Ministry of Health and the Ministry for Technological Innovation and Digitalization.",
+  "website": "https://www.immuni.italia.it/",
+  "license": [
+    {
+      "spdx": "AGPL-3.0",
+      "licenseURL": "https://github.com/immuni-app/immuni-app-ios/blob/development/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/immuni-app/immuni-app-ios",
+  "organizations": [
+    {
+      "name": "Presidenza del Consiglio dei Ministri",
+      "org_type": "owner",
+      "contact_email": "o.cardia@me.com"
+    }
+  ]
+}

--- a/products/neighbor-express.json
+++ b/products/neighbor-express.json
@@ -1,0 +1,28 @@
+{
+  "name": "Neighbor Express",
+  "description": "The City of Concord, California worked with USDR to create a volunteer-matching system that connects community volunteers to vulnerable populations for groceries, deliveries, and check-ins. It has already been rapidly adapted for two other cities. It has since been scaled to Walnut Cree, California and Paterson, New Jersey.",
+  "website": "https://neighborexpress.org",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/usdigitalresponse/neighbor-express/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/usdigitalresponse/neighbor-express",
+  "organizations": [
+    {
+      "name": "The City of Concord, CA",
+      "org_type": "owner",
+      "contact_email": "neighborexpress@gmail.com"
+    }
+  ]
+}

--- a/products/new-jersey-career-network.json
+++ b/products/new-jersey-career-network.json
@@ -1,0 +1,36 @@
+{
+  "name": "New Jersey Career Network",
+  "description": "An initiative developed in partnership with the New Jersey Department of Labor and Workforce Development and the John J. Heldrich Center for Workforce Development at Rutgers University to create 21st century in-person services and digital tools to enable job seekers to identify, prepare for, and obtain jobs.",
+  "website": "https://careers.gardenstate.tech",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/newjersey/career-network/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ],
+    [
+      4,
+      "Quality Education"
+    ],
+    [
+      8,
+      "Decent Work and Economic Growth"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/newjersey/career-network",
+  "organizations": [
+    {
+      "name": "State of New Jersey Office of Innovation",
+      "org_type": "owner",
+      "contact_email": "team@innovation.nj.gov"
+    }
+  ]
+}

--- a/products/nextstrain.json
+++ b/products/nextstrain.json
@@ -1,0 +1,29 @@
+{
+  "name": "NextStrain",
+  "description": "Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data, made available through GISAID. Their goal is to aid epidemiological understanding and improve outbreak response. This build includes data for coronavirus.",
+  "website": "https://nextstrain.org/ncov",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/nextstrain/ncov/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "data",
+    "software"
+  ],
+  "repositoryURL": "https://github.com/nextstrain/ncov",
+  "organizations": [
+    {
+      "name": "NextStrain",
+      "org_type": "owner",
+      "contact_email": "hello@nextstrain.org"
+    }
+  ]
+}

--- a/products/nova-scotia-self-assessment-tool.json
+++ b/products/nova-scotia-self-assessment-tool.json
@@ -1,0 +1,27 @@
+{
+  "name": "Nova Scotia Self-Assessment Tool",
+  "description": "A self-assesment tool to determine if residents of Nova Scotia, Canada should call 811 about potential COVID-19 symptoms.",
+  "website": "https://when-to-call-about-covid19.novascotia.ca/en",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/Nova-Scotia-Digital-Service/when-to-call-811/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/Nova-Scotia-Digital-Service/when-to-call-811",
+  "organizations": [
+    {
+      "name": "Nova Scotia Digital Service",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/open-covid-19-dataset.json
+++ b/products/open-covid-19-dataset.json
@@ -1,0 +1,29 @@
+{
+  "name": "Open COVID-19 Dataset",
+  "description": "A location for summaries and analyses of data related to n-CoV 2019. Referenced in a White House press briefing as the \"Chris Murray Model.\"",
+  "website": "https://covid19.healthdata.org/united-states-of-america",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/beoutbreakprepared/nCoV2019/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software",
+    "data"
+  ],
+  "repositoryURL": "https://github.com/beoutbreakprepared/nCoV2019",
+  "organizations": [
+    {
+      "name": "Institute for Health Metrics and Evaluation, University of Washington",
+      "org_type": "owner",
+      "contact_email": "pigottdm@uw.edu"
+    }
+  ]
+}

--- a/products/open-opportunities-platform.json
+++ b/products/open-opportunities-platform.json
@@ -1,0 +1,35 @@
+{
+  "name": "Open Opportunities platform",
+  "description": "A United States government program that is creating a network of federal employees working together to build a more effective, efficient, responsive government by sharing skills and collaborating on projects that support the mission of an agency or the government as a whole.",
+  "website": "https://openopps.org/",
+  "license": [
+    {
+      "spdx": "CC0-1.0",
+      "licenseURL": "https://github.com/openopps/openopps-platform/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ],
+    [
+      11,
+      "Sustainable Cities and Communities"
+    ],
+    [
+      16,
+      "Peace, Justice and Strong Institutions"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/openopps/openopps-platform",
+  "organizations": [
+    {
+      "name": "The United States General Services Administration",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/opentrace-android.json
+++ b/products/opentrace-android.json
@@ -1,0 +1,28 @@
+{
+  "name": "OpenTrace Android",
+  "description": "Using Bluetooth, OpenTrace identifies other nearby phones with the app installed. It then tracks when you are in close proximity with these other persons, including timestamps. It is the generic codebase on which the Singaporean TraceTogether contact tracing app is built.",
+  "website": "https://www.tracetogether.gov.sg/",
+  "license": [
+    {
+      "spdx": "GPL-3.0",
+      "licenseURL": "https://github.com/opentrace-community/opentrace-android/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/opentrace-community/opentrace-android",
+  "organizations": [
+    {
+      "name": "Government Technology Agency of Singapore",
+      "org_type": "owner",
+      "contact_email": "partnerships@tracetogether.gov.sg"
+    }
+  ]
+}

--- a/products/opentrace-ios.json
+++ b/products/opentrace-ios.json
@@ -1,0 +1,28 @@
+{
+  "name": "OpenTrace iOS",
+  "description": "Using Bluetooth, OpenTrace identifies other nearby phones with the app installed. It then tracks when you are in close proximity with these other persons, including timestamps. It is the generic codebase on which the Singaporean TraceTogether contact tracing app is built.",
+  "website": "https://www.tracetogether.gov.sg/",
+  "license": [
+    {
+      "spdx": "GPL-3.0",
+      "licenseURL": "https://github.com/opentrace-community/opentrace-ios/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/opentrace-community/opentrace-ios",
+  "organizations": [
+    {
+      "name": "Government Technology Agency of Singapore",
+      "org_type": "owner",
+      "contact_email": "partnerships@tracetogether.gov.sg"
+    }
+  ]
+}

--- a/products/pandemic-ebt.json
+++ b/products/pandemic-ebt.json
@@ -1,0 +1,28 @@
+{
+  "name": "Pandemic EBT",
+  "description": "Rails app to support online Pandemic EBT (P-EBT) applications in California. P-EBT benefits help families in California buy food when school is closed.",
+  "website": "https://ca.p-ebt.org/en/",
+  "license": [
+    {
+      "spdx": "BSD-3-Clause",
+      "licenseURL": "https://github.com/codeforamerica/pandemic-ebt-ca/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/codeforamerica/pandemic-ebt",
+  "organizations": [
+    {
+      "name": "Code for America",
+      "org_type": "owner",
+      "contact_email": ""
+    }
+  ]
+}

--- a/products/privatetracer.json
+++ b/products/privatetracer.json
@@ -1,0 +1,28 @@
+{
+  "name": "PrivateTracer",
+  "description": "A bluetooth-based contact tracing app being developed by the the Municipality of the Hague and other private and nonprofit partners. It abides by the DP-3T privacy protocol specifications and processes location and bluetooth data locally on the user's smartphone.",
+  "website": "https://gitlab.com/PrivateTracer",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://gitlab.com/PrivateTracer/ios-client/-/blob/develop/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://gitlab.com/PrivateTracer/ios-client",
+  "organizations": [
+    {
+      "name": "PrivateTracer Foundation",
+      "org_type": "owner",
+      "contact_email": "contribute@privatetracer.org"
+    }
+  ]
+}

--- a/products/project-papua.json
+++ b/products/project-papua.json
@@ -1,0 +1,27 @@
+{
+  "name": "Project PAPUA",
+  "description": "The Pilot Application for Pandemic Unemployment Assistance (PAPUA) project is a prototype service providing a unified unemployment intake form and delivers validated unemployment claims to various State backends. This project is a volunteer-led effort and part of the US Digital Response network. It was been adopted by the State of New Jersey.",
+  "website": "https://papua.usdigitalresponse.org/",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/usdigitalresponse/project-papua/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/usdigitalresponse/project-papua",
+  "organizations": [
+    {
+      "name": "US Digital Response",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/rakning-c-19-app.json
+++ b/products/rakning-c-19-app.json
@@ -1,0 +1,27 @@
+{
+  "name": "Rakning C-19 App",
+  "description": "An app that can be downloaded voluntarily and facilitates the contact tracing process amidst the ongoing Covid-19 pandemic in Iceland.",
+  "website": "https://covid.is/app",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/aranja/rakning-c19-app/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/aranja/rakning-c19-app",
+  "organizations": [
+    {
+      "name": "Icelandic Directorate of Health and the Department of Civil Protection and Emergency Management.",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/sante-publique-france-covid-19-dashboard.json
+++ b/products/sante-publique-france-covid-19-dashboard.json
@@ -1,0 +1,27 @@
+{
+  "name": "Santé publique France COVID-19 Dashboard",
+  "description": "Santé Publique France, the French public health agency responsible for monitoring health security and implementing appropriate responses, has compiled official information on the COVID-19 outbreak from regional health agencies, prefectures, and other authorities and represented this information graphically in a dashboard.",
+  "website": "https://dashboard.covid19.data.gouv.fr/vue-d-ensemble",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/etalab/covid19-dashboard/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/etalab/covid19-dashboard",
+  "organizations": [
+    {
+      "name": "Santé Publique France",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/sante-publique-france-covid-19-dashboard.json
+++ b/products/sante-publique-france-covid-19-dashboard.json
@@ -1,6 +1,6 @@
 {
-  "name": "Santé publique France COVID-19 Dashboard",
-  "description": "Santé Publique France, the French public health agency responsible for monitoring health security and implementing appropriate responses, has compiled official information on the COVID-19 outbreak from regional health agencies, prefectures, and other authorities and represented this information graphically in a dashboard.",
+  "name": "SantÃ© publique France COVID-19 Dashboard",
+  "description": "SantÃ© Publique France, the French public health agency responsible for monitoring health security and implementing appropriate responses, has compiled official information on the COVID-19 outbreak from regional health agencies, prefectures, and other authorities and represented this information graphically in a dashboard.",
   "website": "https://dashboard.covid19.data.gouv.fr/vue-d-ensemble",
   "license": [
     {
@@ -20,7 +20,7 @@
   "repositoryURL": "https://github.com/etalab/covid19-dashboard",
   "organizations": [
     {
-      "name": "Santé Publique France",
+      "name": "SantÃ© Publique France",
       "org_type": "owner"
     }
   ]

--- a/products/sars-cov-2-open-government-data-reported-by-the-swiss-cantons-and-the-principality-of-liechtenstein.json
+++ b/products/sars-cov-2-open-government-data-reported-by-the-swiss-cantons-and-the-principality-of-liechtenstein.json
@@ -1,0 +1,27 @@
+{
+  "name": "SARS-CoV-2 Open Government Data reported by the Swiss Cantons and the Principality of Liechtenstein",
+  "description": "A common official OGD dataset of SARS-CoV-2 cases for the Swiss Authorities. SARS-CoV-2 case numbers are provided in machine-readable form (CSV) as OGD resources (Open Government Data), that have been published by official sources (Cantons and FL) online.",
+  "license": [
+    {
+      "spdx": "CC-BY-4.0",
+      "licenseURL": "https://github.com/openZH/covid_19/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "data"
+  ],
+  "repositoryURL": "https://github.com/openZH/covid_19",
+  "organizations": [
+    {
+      "name": "The Canton of Zurich",
+      "org_type": "owner",
+      "contact_email": "datashop@statistik.zh.ch"
+    }
+  ]
+}

--- a/products/sars-cov-2-sequencing-resources.json
+++ b/products/sars-cov-2-sequencing-resources.json
@@ -1,0 +1,32 @@
+{
+  "name": "SARS-CoV-2 Sequencing Resources",
+  "description": "This document repository is meant to serve as the start of a crowd-sourced collection of information, documentation, protocols and other resources for public health laboratories intending to sequence SARS-CoV-2 coronavirus samples in the coming weeks.",
+  "website": "https://github.com/CDCgov/SARS-CoV-2_Sequencing",
+  "license": [
+    {
+      "spdx": "Apache-2.0",
+      "licenseURL": "https://github.com/CDCgov/SARS-CoV-2_Sequencing/blob/master/LICENSE"
+    },
+    {
+      "spdx": "CC0-1.0",
+      "licenseURL": "https://github.com/CDCgov/SARS-CoV-2_Sequencing/blob/master/README.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "content"
+  ],
+  "repositoryURL": "https://github.com/CDCgov/SARS-CoV-2_Sequencing",
+  "organizations": [
+    {
+      "name": "The Center for Disease Control",
+      "org_type": "owner",
+      "contact_email": "https://www.twitter.com/dmaccannell"
+    }
+  ]
+}

--- a/products/stopcovid-android.json
+++ b/products/stopcovid-android.json
@@ -1,6 +1,6 @@
 {
   "name": "StopCovid Android",
-  "description": "A digital contact tracing app supported by the French government. Created by the French state research agency INRIA, with the support of French companies such as Orange, Capgemini and Dassault Systèms, the app follows the ROBERT privacy framework which allows for proximity data to be collected and stored in a central database, such as by a Ministry of Health.",
+  "description": "A digital contact tracing app supported by the French government. Created by the French state research agency INRIA, with the support of French companies such as Orange, Capgemini and Dassault SystÃ¨ms, the app follows the ROBERT privacy framework which allows for proximity data to be collected and stored in a central database, such as by a Ministry of Health.",
   "website": "https://gitlab.inria.fr/stopcovid19",
   "license": [
     {

--- a/products/stopcovid-android.json
+++ b/products/stopcovid-android.json
@@ -1,0 +1,28 @@
+{
+  "name": "StopCovid Android",
+  "description": "A digital contact tracing app supported by the French government. Created by the French state research agency INRIA, with the support of French companies such as Orange, Capgemini and Dassault Systèms, the app follows the ROBERT privacy framework which allows for proximity data to be collected and stored in a central database, such as by a Ministry of Health.",
+  "website": "https://gitlab.inria.fr/stopcovid19",
+  "license": [
+    {
+      "spdx": "MPL-2.0",
+      "licenseURL": "https://gitlab.inria.fr/stopcovid19/stopcovid-android/-/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://gitlab.inria.fr/stopcovid19/stopcovid-android",
+  "organizations": [
+    {
+      "name": "INRIA",
+      "org_type": "owner",
+      "contact_email": "stopcovid@lunabee.com"
+    }
+  ]
+}

--- a/products/stopcovid-ios.json
+++ b/products/stopcovid-ios.json
@@ -1,0 +1,28 @@
+{
+  "name": "StopCovid iOS",
+  "description": "A digital contact tracing app supported by the French government. Created by the French state research agency INRIA, with the support of French companies such as Orange, Capgemini and Dassault Systèms, the app follows the ROBERT privacy framework which allows for proximity data to be collected and stored in a central database, such as by a Ministry of Health.",
+  "website": "https://gitlab.inria.fr/stopcovid19",
+  "license": [
+    {
+      "spdx": "MPL-2.0",
+      "licenseURL": "https://gitlab.inria.fr/stopcovid19/stopcovid-ios/-/blob/master/LICENSE.md"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://gitlab.inria.fr/stopcovid19/stopcovid-ios",
+  "organizations": [
+    {
+      "name": "INRIA",
+      "org_type": "owner",
+      "contact_email": "stopcovid@lunabee.com"
+    }
+  ]
+}

--- a/products/stopcovid-ios.json
+++ b/products/stopcovid-ios.json
@@ -1,6 +1,6 @@
 {
   "name": "StopCovid iOS",
-  "description": "A digital contact tracing app supported by the French government. Created by the French state research agency INRIA, with the support of French companies such as Orange, Capgemini and Dassault Systèms, the app follows the ROBERT privacy framework which allows for proximity data to be collected and stored in a central database, such as by a Ministry of Health.",
+  "description": "A digital contact tracing app supported by the French government. Created by the French state research agency INRIA, with the support of French companies such as Orange, Capgemini and Dassault SystÃ¨ms, the app follows the ROBERT privacy framework which allows for proximity data to be collected and stored in a central database, such as by a Ministry of Health.",
   "website": "https://gitlab.inria.fr/stopcovid19",
   "license": [
     {

--- a/products/swisscovid.json
+++ b/products/swisscovid.json
@@ -1,0 +1,28 @@
+{
+  "name": "SwissCovid",
+  "description": "An open protocol and mobile app for COVID-19 proximity tracing using Bluetooth Low Energy functionality on mobile devices that ensures personal data and computation stays entirely on an individual's phone. It was produced by a team of European scientists and academics, and has been endorsed by the Swiss government.",
+  "website": "https://github.com/DP-3T/dp3t-app-ios",
+  "license": [
+    {
+      "spdx": "MPL-2.0",
+      "licenseURL": "https://github.com/DP-3T/dp3t-app-ios-demo/blob/develop/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/DP-3T",
+  "organizations": [
+    {
+      "name": "Ecole Polytechnique Federale de Lausanne and ETH Zurich",
+      "org_type": "owner",
+      "contact_email": "dp3t@groupes.epfl.ch"
+    }
+  ]
+}

--- a/products/talent-cloud.json
+++ b/products/talent-cloud.json
@@ -1,0 +1,32 @@
+{
+  "name": "Talent Cloud",
+  "description": "The Government of Canada Digital and Technology Community is working hard to support the operations of the Government of Canada during the COVID-19 pandemic. Some teams will be needing additional support during this time as they work on priority areas. This tool is designed to identify existing, skilled, Government of Canada employees who may be able to temporarily support those needs.",
+  "website": "https://talent.canada.ca/response/en",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/GCTC-NTGC/TalentCloud/blob/dev/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ],
+    [
+      16,
+      "Peace, Justice and Strong Institutions"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/GCTC-NTGC/TalentCloud",
+  "organizations": [
+    {
+      "name": "Government of Canada Talent Reserve",
+      "org_type": "owner",
+      "contact_email": "Talent.Cloud-nuage.de.talents@tbs-sct.gc.ca"
+    }
+  ]
+}

--- a/products/tokyo-metropolitan-government-covid-19-countermeasure-site.json
+++ b/products/tokyo-metropolitan-government-covid-19-countermeasure-site.json
@@ -1,0 +1,31 @@
+{
+  "name": "Tokyo Metropolitan Government COVID-19 Countermeasure Site",
+  "description": "A data visualization website that conveys an updated, digestible dataset to reflect the status of the spread of coronavirus within the city. The site has been reused by the City and County of San Francisco.",
+  "website": "https://stopcovid19.metro.tokyo.lg.jp/en/",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/tokyo-metropolitan-gov/covid19/blob/development/LICENSE.txt"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ],
+    [
+      16,
+      "Peace, Justice and Strong Institutions"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/tokyo-metropolitan-gov/covid19",
+  "organizations": [
+    {
+      "name": "Tokyo Metropolitan Government",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/products/traction-thrive.json
+++ b/products/traction-thrive.json
@@ -1,0 +1,27 @@
+{
+  "name": "Traction Thrive",
+  "description": "An application that enables hospitals and healthcare practitioners to more accurately track and distribute critical medical staff and resources to meet the immediate needs of COVID-19 response teams. It was created by Traction On Demand in partnership with Thrive Health and initially rolled out with the Provincial Health Services Authority of British Columbia.",
+  "website": "https://tractionondemand.com/traction-thrive/",
+  "license": [
+    {
+      "spdx": "BSD-3-Clause",
+      "licenseURL": "https://github.com/SFDO-Community/TractionThrive/blob/master/LICENSE"
+    }
+  ],
+  "SDGs": [
+    [
+      3,
+      "Good Health and Well-Being"
+    ]
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/SFDO-Community/TractionThrive",
+  "organizations": [
+    {
+      "name": "Traction Thrive, Salesforce.org",
+      "org_type": "owner"
+    }
+  ]
+}

--- a/scripts/check-filenames.bash
+++ b/scripts/check-filenames.bash
@@ -11,7 +11,7 @@ pushd $SELFDIR/.. > /dev/null 2>&1
 
 if [ `ls -1 ./products/*.json 2>/dev/null | wc -l` -gt 0 ]; then
 	for f in ./products/*.json; do
-	    filename=`grep -Eo -m 1 '"name":.*?[^\\]",' "$f" | awk -F':' '{print $2}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]/-/g' -e 's/---/-/g' -e 'y/āáǎàēéěèīíǐìōóǒòūúǔùüǖǘǚǜĀÁǍÀĒÉĚÈĪÍǏÌŌÓǑÒŪÚǓÙÜǕǗǙǛ/aaaaeeeeiiiioooouuuuuuuuuAAAAEEEEIIIIOOOOUUUUUUUUU/'| tr '[:upper:]' '[:lower:]'`
+	    filename=`grep -Eo -m 1 '"name":.*?[^\\]",' "$f" | awk -F':' '{print $2}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]/-/g' -e 's/---/-/g' -e 'y/āáǎàēéěèīíǐìōóǒòūúǔùüǖǘǚǜĀÁǍÀĒÉĚÈĪÍǏÌŌÓǑÒŪÚǓÙÜǕǗǙǛš/aaaaeeeeiiiioooouuuuuuuuuAAAAEEEEIIIIOOOOUUUUUUUUUs/'| tr '[:upper:]' '[:lower:]'`
 	    if [ "$filename.json" = "$(basename -- "$f")" ]; then
 	    	echo "Filename is valid: $filename.json"
 	    else


### PR DESCRIPTION
Propagating changes from unicef/publicgoods-candidates#65:

Added nominees from [newamericafoundation/pandemic-response-repository](https://github.com/newamericafoundation/pandemic-response-repository/), from [this file](https://github.com/newamericafoundation/pandemic-response-repository/blob/master/_data/projects.csv) specifically.